### PR TITLE
Do not show hardcode block when none found

### DIFF
--- a/src/components/Panel.tsx
+++ b/src/components/Panel.tsx
@@ -77,7 +77,11 @@ export class DesignTokenPanel extends React.Component<Props, any> {
 
           <Separator />
 
-          <HardCodedValuesTable hardCodedValues={this.props.hardCodedValues} />
+          {this.props.hardCodedValues.length && (
+            <HardCodedValuesTable
+              hardCodedValues={this.props.hardCodedValues}
+            />
+          )}
         </Container>
       </>
     );


### PR DESCRIPTION
Hey!

First of all. You’ve worked so hard for this. Congrats!

but... :P 

¿Can we hide "Hard Coded Values" block when there is not values?

Preview: 
![image](https://user-images.githubusercontent.com/8685132/83873129-7bc68580-a733-11ea-9f4b-922d6f1ec069.png)

The package not found any hard coded value inside our project but still showing the dropdown with empty block