### PR TITLE
make border radius previews resizable

### DIFF
--- a/addon/src/components/presenter/BorderRadiusPresenter.tsx
+++ b/addon/src/components/presenter/BorderRadiusPresenter.tsx
@@ -26,9 +26,13 @@ export const BorderRadiusPresenter = ({
         background: theme.color.secondary,
         borderRadius: token.value,
         height: 32,
-        minHeight: `calc(${token.value} * 2)`,
-        minWidth: `calc(${token.value} * 2)`,
-        width: '100%'
+        width: '100%',
+        minHeight: 16,
+        minWidth: 16,
+        maxHeight: 160,
+        maxWidth: '100%',
+        resize: 'both',
+        overflow: 'hidden'
       })),
     [token]
   );


### PR DESCRIPTION
Hi there. Came to report the same issue as #41. This would fix it by making border radius boxes resizable with a default height/width and removing the calculated piece.

Created the fork/PR in Github's web editor, so hopefully everything's alright syntax-wise. 😬 Let me know what you think. Thanks!