### PR TITLE
Get docs parameters across storybook versions

### DIFF
--- a/addon/src/components/DesignTokenDocBlock.tsx
+++ b/addon/src/components/DesignTokenDocBlock.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useMemo } from 'react';
 
-import { DocsContext } from '@storybook/addon-docs/blocks';
+import { DocsContext, DocsContextProps } from '@storybook/addon-docs/blocks';
 import { styled } from '@storybook/theming';
 
 import { useTokenTabs } from '../hooks/useTokenTabs';
@@ -12,12 +12,27 @@ export interface DesignTokenDocBlockProps {
   viewType?: 'card' | 'table';
 }
 
+interface CompatDocsContextProps extends DocsContextProps {
+  storyById?: (id: string) => any;
+}
+
+/**
+ * Storybook 6.4 changed the DocsContextProps interface.
+ * This is a compatibility method to get docs parameters across Storybook versions.
+ */
+function getMainStory(context: CompatDocsContextProps) {
+  return typeof context.storyById === 'function' ?
+    context.storyById(context.id!) :
+    context;
+}
+
 export const DesignTokenDocBlock = ({
   categoryName,
   viewType = 'table'
 }: DesignTokenDocBlockProps) => {
   const context = useContext(DocsContext);
-  const { tabs } = useTokenTabs(context.parameters.designToken);
+  const story = getMainStory(context);
+  const { tabs } = useTokenTabs(story.parameters.designToken);
 
   const tab = useMemo(() => tabs.find((t) => t.label === categoryName), [
     categoryName,


### PR DESCRIPTION
Hello @Sqrrl!

This PR should fix the issue reported here (#59) and prepare the addon for the upcoming 6.4 Storybook release. 
Feel free to ignore it for the moment, if you prefer to wait for the stable release, but it should be backward compatible.