### PR TITLE
Extend SVG information

### DIFF
--- a/addon/src/components/TokenCards.tsx
+++ b/addon/src/components/TokenCards.tsx
@@ -44,6 +44,11 @@ export const TokenCards = ({ categories, readonly }: TokenCardsProps) => {
 
         '> *:not(:last-child)': {
           marginBottom: 8
+        },
+
+        'svg': {
+          maxWidth: "100%",
+          maxHeight: "100%",
         }
       })),
     []

--- a/addon/src/components/TokenTable.tsx
+++ b/addon/src/components/TokenTable.tsx
@@ -91,6 +91,11 @@ export const TokenTable = ({ categories, readonly }: TokenTableProps) => {
 
           ':not(:last-of-type)': {
             paddingRight: 15
+          },
+
+          'svg': {
+            maxWidth: "100%",
+            maxHeight: "100%",
           }
         }
       })),

--- a/addon/src/hooks/useTokenTabs.ts
+++ b/addon/src/hooks/useTokenTabs.ts
@@ -11,7 +11,7 @@ export function useTokenTabs(config?: Config) {
   const [cssCategories, setCssCategories] = useState<Category[]>([]);
   const [lessCategories, setLessCategories] = useState<Category[]>([]);
   const [scssCategories, setScssCategories] = useState<Category[]>([]);
-  const [svgIconCategory, setSvgIconCategory] = useState<Category>();
+  const [svgIconCategories, setSvgIconCategories] = useState<Category[]>([]);
 
   const [activeCategory, setActiveCategory] = useState<string>();
   const [cardView, setCardView] = useStorageState(
@@ -27,7 +27,7 @@ export function useTokenTabs(config?: Config) {
       ...cssCategories,
       ...lessCategories,
       ...scssCategories,
-      svgIconCategory
+      ...svgIconCategories,
     ].filter(
       (category) => category !== undefined && category?.tokens.length > 0
     );
@@ -42,7 +42,7 @@ export function useTokenTabs(config?: Config) {
         (category) => category?.name === name
       ) as Category[]
     }));
-  }, [cssCategories, lessCategories, scssCategories, svgIconCategory]);
+  }, [cssCategories, lessCategories, scssCategories, svgIconCategories]);
 
   useEffect(() => {
     const cssFiles = config?.files?.filter((file) =>
@@ -102,8 +102,8 @@ export function useTokenTabs(config?: Config) {
       }
     );
 
-    parseSvgFiles(svgFiles).then((category) => {
-      setSvgIconCategory(category);
+    parseSvgFiles(svgFiles).then((categories) => {
+      setSvgIconCategories(categories);
     });
   }, [config]);
 

--- a/addon/src/parsers/svg-icon.parser.ts
+++ b/addon/src/parsers/svg-icon.parser.ts
@@ -2,12 +2,16 @@ import { Category } from '../types/category.types';
 import { File } from '../types/config.types';
 import { Token, TokenPresenter, TokenSourceType } from '../types/token.types';
 
-export async function parseSvgFiles(files: File[] = []): Promise<Category> {
-  return {
-    name: 'SVG Icons',
-    presenter: TokenPresenter.SVG,
-    tokens: determineTokens(files)
-  };
+export async function parseSvgFiles(files: File[] = []): Promise<Category[]> {
+  const tokens = determineTokens(files);
+  let categoryNames = tokens.map(token => token.categoryName).filter((v, i, a) => a.indexOf(v) === i);
+  return categoryNames.map(name => {
+    return {
+      name: name || "SVG Icons",
+      presenter: TokenPresenter.SVG,
+      tokens: tokens.filter(token => token.categoryName === name)
+    }
+  });
 }
 
 function determineTokens(files: File[]): Token[] {
@@ -28,6 +32,12 @@ function determineTokens(files: File[]): Token[] {
             svg?.getAttribute('data-token-name') ||
             svg?.getAttribute('id') ||
             '',
+          description:
+            svg?.getAttribute('data-token-description') ||
+            '',
+          categoryName:
+            svg?.getAttribute('data-token-category') ||
+            'SVG Icons',
           presenter: TokenPresenter.SVG,
           rawValue: svg.outerHTML,
           sourceType: TokenSourceType.SVG,

--- a/addon/src/types/token.types.ts
+++ b/addon/src/types/token.types.ts
@@ -2,6 +2,7 @@ export interface Token {
   description?: string;
   isAlias?: boolean;
   name: string;
+  categoryName?: string;
   presenter?: TokenPresenter;
   rawValue: string;
   sourceType: TokenSourceType;


### PR DESCRIPTION
SVG files can provide a category name and a description like the other tokens by using data attributes on each SVG element.

Data attributes added:

- `data-token-category`
- `data-token-description`

Fix #56
