### PR TITLE
Use svg file name as a name for svg token

### DIFF
--- a/addon/src/parsers/svg-icon.parser.ts
+++ b/addon/src/parsers/svg-icon.parser.ts
@@ -41,11 +41,11 @@ function determineTokens(files: File[]): Token[] {
       const name = basename(file.filename, extname(file.filename));
 
       return svgs
-        .map((svg) => ({
+        .map((svg, index, array) => ({
           name:
             svg?.getAttribute('data-token-name') ||
             svg?.getAttribute('id') ||
-            name,
+            (array.length > 1 ? `${name}-${index + 1}`: name),
           description: svg?.getAttribute('data-token-description') || '',
           categoryName: svg?.getAttribute('data-token-category') || 'SVG Icons',
           presenter: TokenPresenter.SVG,

--- a/addon/src/parsers/svg-icon.parser.ts
+++ b/addon/src/parsers/svg-icon.parser.ts
@@ -1,4 +1,5 @@
 import { JSDOM } from 'jsdom';
+import { basename, extname } from 'path';
 
 import { Category } from '../types/category.types';
 import { File } from '../types/config.types';
@@ -37,13 +38,14 @@ function determineTokens(files: File[]): Token[] {
       div.innerHTML = file.content;
 
       const svgs = Array.from(div.querySelectorAll('svg'));
+      const name = basename(file.filename, extname(file.filename));
 
       return svgs
         .map((svg) => ({
           name:
             svg?.getAttribute('data-token-name') ||
             svg?.getAttribute('id') ||
-            '',
+            name,
           description: svg?.getAttribute('data-token-description') || '',
           categoryName: svg?.getAttribute('data-token-category') || 'SVG Icons',
           presenter: TokenPresenter.SVG,


### PR DESCRIPTION
These changes solve the problem I've described in https://github.com/UX-and-I/storybook-design-token/issues/93:

# The problem

Currently, I need to modify every svg file to add either id or data-token-name. It makes it hard to use the addon for any existing project.

# Solution

To make it easier to use the addon for existing projects we could use file name to specify the token name. In this case, it will not be necessary to go and modify all existing svg files.

# Before changes

The whole existing project contains a single svg file that has id.

![Screenshot 2022-04-23 at 14 07 36](https://user-images.githubusercontent.com/9947582/164891981-f022042a-611c-4d5f-85fa-eeec9d272d9a.png)

# After changes

All existing svg files are visible in the panel

![image](https://user-images.githubusercontent.com/9947582/164892012-91e63f2f-51e6-4845-bd07-8a8f61a58f5f.png)
