### PR TITLE
Fix error that is cause by oneline (//) error in less file

### DIFF
--- a/addon/src/parsers/postcss.parser.ts
+++ b/addon/src/parsers/postcss.parser.ts
@@ -234,7 +234,7 @@ async function getNodes(
 
   await Promise.all(
     files.map((file) => {
-      const syntax: any = file.filename.endsWith('.scss') ? scss : undefined;
+      const syntax: any = (file.filename.endsWith('.scss') || file.filename.endsWith('.less')) ? scss : undefined;
 
       return postcss([plugin]).process(file.content, {
         from: file.filename,


### PR DESCRIPTION
# The issue

Compilation error happens when parsing the `*.less` that uses oneline comment (`// comment`) in less file, as default css parser is used for less files

# Error message
```
/node_modules/storybook-design-token/node_modules/postcss/lib/input.js:148
      result = new CssSyntaxError(
               ^

CssSyntaxError: /Users/cherkalexander/Documents/projects/platform/hosts/Decisions.Web.Core/wwwroot/styles/Less/themes/theme.portal.less:184:66: Unknown word
You tried to parse Less with the standard CSS parser; try again with the postcss-less parser
    at Input.error (/node_modules/storybook-design-token/node_modules/postcss/lib/input.js:148:16)
    at Parser.unknownWord (/node_modules/storybook-design-token/node_modules/postcss/lib/parser.js:540:22)
    at Parser.other (/node_modules/storybook-design-token/node_modules/postcss/lib/parser.js:164:12)
    at Parser.parse (/node_modules/storybook-design-token/node_modules/postcss/lib/parser.js:72:16)
    at parse (/node_modules/storybook-design-token/node_modules/postcss/lib/parse.js:11:12)
    at new LazyResult (/node_modules/storybook-design-token/node_modules/postcss/lib/lazy-result.js:133:16)
    at Processor.process (/node_modules/storybook-design-token/node_modules/postcss/lib/processor.js:28:14)
    at /node_modules/storybook-design-token/dist/parsers/postcss.parser.js:214:69
    at Array.map (<anonymous>)
    at /node_modules/storybook-design-token/dist/parsers/postcss.parser.js:212:60
    at step (/node_modules/storybook-design-token/dist/parsers/postcss.parser.js:44:23)
    at Object.next (/node_modules/storybook-design-token/dist/parsers/postcss.parser.js:25:53)
    at /node_modules/storybook-design-token/dist/parsers/postcss.parser.js:19:71
    at new Promise (<anonymous>)
    at __awaiter (/node_modules/storybook-design-token/dist/parsers/postcss.parser.js:15:12)
    at getNodes (/node_modules/storybook-design-token/dist/parsers/postcss.parser.js:180:12) {
```