### PR TITLE
White icons/colors are not visible

### DIFF
--- a/addon/src/components/TokenCards.tsx
+++ b/addon/src/components/TokenCards.tsx
@@ -61,6 +61,10 @@ export const TokenCards = ({
         padding: 12,
         overflow: 'hidden',
 
+        ':hover': {
+          backgroundColor: theme.background.hoverable,
+        },
+
         '> *:not(:last-child)': {
           marginBottom: 8
         },

--- a/addon/src/components/TokenTable.tsx
+++ b/addon/src/components/TokenTable.tsx
@@ -97,6 +97,10 @@ export const TokenTable = ({
 
           ':last-of-type': {
             borderBottom: `1px solid ${theme.color.mediumlight}`
+          },
+
+          ':hover': {
+            backgroundColor: theme.background.hoverable,
           }
         },
 


### PR DESCRIPTION
Without hover

<img width="343" alt="image" src="https://user-images.githubusercontent.com/9947582/226531947-a59fbbcb-6693-4dd5-bffc-bcd7c959c2c0.png">

<img width="674" alt="image" src="https://user-images.githubusercontent.com/9947582/226532114-63b77822-25e2-4574-a9e7-67359a6d2785.png">

When card/row hovered

<img width="349" alt="image" src="https://user-images.githubusercontent.com/9947582/226531985-396826cc-0d34-49b5-b383-3061f8a5f7b5.png">

<img width="675" alt="image" src="https://user-images.githubusercontent.com/9947582/226532034-d7f34dc1-be04-4ab7-a897-6a3e41d8b96b.png">

