### PR TITLE
Fixing typo in package exports

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -35,7 +35,7 @@
       "import": "./dist/preset.mjs",
       "types": "./dist/preset.d.ts"
     },
-    "./doc-bocks": {
+    "./doc-blocks": {
       "require": "./dist/doc-blocks.js",
       "import": "./dist/doc-blocks.mjs",
       "types": "./dist/doc-blocks.d.ts"


### PR DESCRIPTION
Minor typo in the package.json file is preventing usage of the beta versions-.