### PR TITLE
Update manager.ts, remove deprecated 'key' arg

### DIFF
--- a/addon/src/manager.ts
+++ b/addon/src/manager.ts
@@ -9,11 +9,11 @@ addons.register(ADDON_ID, () => {
     title: "Design Tokens",
     paramKey: PARAM_KEY,
     match: ({ viewMode }) => viewMode === "story",
-    render: ({ active, key }) => {
+    render: ({ active }) => {
       if (!active) {
         return null;
       }
-      return React.createElement(Panel, { key, active });
+      return React.createElement(Panel, { active });
     },
   });
 });


### PR DESCRIPTION
Fixes React error in console in storybook 7.2.0+

See https://github.com/storybookjs/storybook/issues/23782
And the PR that fixes it in https://github.com/storybookjs/storybook/pull/23792 