### PR TITLE
Icons do not respect theme color and thus not visible when dark mode is used

### DIFF
--- a/addon/src/components/ToolButton.tsx
+++ b/addon/src/components/ToolButton.tsx
@@ -22,6 +22,7 @@ export const ToolButton = ({ children, onClick }: ToolButtonProps) => {
         padding: 0,
         verticalAlign: "middle",
         width: 18,
+        color: theme.color.defaultText,
 
         "&:hover": {
           color: theme.color.secondary,


### PR DESCRIPTION
# Before 

<img width="882" alt="image" src="https://github.com/UX-and-I/storybook-design-token/assets/9947582/73294e5b-1546-4392-be9b-688c34a06a14">


# After

![image](https://github.com/UX-and-I/storybook-design-token/assets/9947582/32986154-f31c-4fc6-8235-577a1cc488e3)
