### PR TITLE
fix(#209) fixes issue with parsing of nested variables

### DIFF
--- a/addon/src/parsers/postcss.parser.ts
+++ b/addon/src/parsers/postcss.parser.ts
@@ -184,36 +184,24 @@ function determineTokenValue(
 ): string {
   rawValue = rawValue.replace(/!default/g, "").replace(/!global/g, "");
 
-  const cssVars = "(var\\(([a-zA-Z0-9-_]+)\\))";
-  const scssVars = "(\\$([a-zA-Z0-9-_]+))";
-  const lessVars = "(\\@([a-zA-Z0-9-_]+))";
-
-  const vars = [!preserveCSSVars && cssVars, scssVars, lessVars].filter(
-    Boolean
-  ) as string[];
-
-  const referencedVariableResult = new RegExp(`^(${vars.join("|")})$`).exec(
-    rawValue
-  );
-
-  const referencedVariable =
-    referencedVariableResult?.[3] ||
-    referencedVariableResult?.[5] ||
-    referencedVariableResult?.[7];
-
-  if (referencedVariable) {
-    const value =
+  const regex = /\bvar\(([^)]+)\)|(\$[a-zA-Z0-9-_]+|@[a-zA-Z0-9-_]+)/g;
+  let match;
+  let replacedString = rawValue;
+  while ((match = regex.exec(rawValue)) !== null) {
+    const variableMatch = match[0];
+    const variableName = variableMatch.replace(/\(|\)|var\(|@|\$/g, "");
+    const replacement =
       declarations.find(
         (declaration) =>
-          declaration.prop === referencedVariable ||
-          declaration.prop === `$${referencedVariable}` ||
-          declaration.prop === `@${referencedVariable}`
+          declaration.prop === variableName ||
+          declaration.prop === `$${variableName}` ||
+          declaration.prop === `@${variableName}`
       )?.value || "";
 
-    return determineTokenValue(value, declarations, preserveCSSVars);
+    replacedString = replacedString.replace(variableMatch, replacement);
   }
 
-  return rawValue;
+  return replacedString;
 }
 
 async function getNodes(files: File[]): Promise<{


### PR DESCRIPTION
Hi! this PR fixes parsing logic in the addon. The fix allows css custom properties to be nested inside the other properties and still have it's value recognized. 

Here's example with `--gradient-with-var` in the [demo](https://storybook-design-token-v1.netlify.app/?path=/docs/demo--docs) before fix:
<img width="981" alt="image" src="https://github.com/UX-and-I/storybook-design-token/assets/33729448/09358c35-020f-4ec8-a6cf-6a2b1ea04782">

and here is the result of the fix:
<img width="978" alt="image" src="https://github.com/UX-and-I/storybook-design-token/assets/33729448/1830e3cd-4ebf-404a-8d2b-1422df0ad5f4">

fixes #209

