### PR TITLE
Add new feature - usageMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,36 @@ import { DesignTokenDocBlock } from 'storybook-design-token';
 
 You can also pass a theme to the `DesignTokenDocBlock` component. This is useful when you have two themes with the same variable names but only want to display the variables for the current theme. Just pass the `theme` property to do this.
 
+### Token Usage Map
+
+You can provide a `usageMap` to the `DesignTokenDocBlock` component to display where each token is used across your components.
+
+This is especially helpful for design teams who want to trace Figma tokens to component usage. When a `usageMap` is provided, users can **right-click a token row** in the table view to open a modal displaying the list of components where the token is used.
+
+**Usage Example:**
+
+```tsx
+<DesignTokenDocBlock
+  categoryName="Colors"
+  usageMap={{
+    '--b100': ['Button', 'CardHeader'],
+    '--b200': ['Modal']
+  }}
+/>
+```
+
+> [!NOTE]
+> The usageMap is an object where keys are token names (e.g., --b100) and values are arrays of component names.
+> Tokens not found in the usage map or mapped to an > empty array will display a fallback message: `This token appears to be global or unused.`
+
+> 💡 Typically, this map is generated in a prebuild step
+> (e.g., using a script that scans your component codebase for token usage).
+
 ## Browser support
 
 - All modern browsers
 - ~~Internet Explorer 11~~
+
+```
+
+```

--- a/addon/package.json
+++ b/addon/package.json
@@ -73,6 +73,7 @@
     "@types/node": "^20.19.0",
     "@types/prettier": "^2.7.2",
     "@types/react": "^19.1.6",
+    "@types/react-dom": "^19.1.1",
     "@vitejs/plugin-react": "^4.5.1",
     "npm-run-all": "^4.1.5",
     "react": "^19.0.0",

--- a/addon/src/components/DesignTokenDocBlock.tsx
+++ b/addon/src/components/DesignTokenDocBlock.tsx
@@ -16,6 +16,7 @@ export interface DesignTokenDocBlockProps {
   showValueColumn?: boolean;
   viewType: TokenViewType;
   filterNames?: string[];
+  usageMap?: Record<string, string[]>;
   theme?: string;
   /**
    * @default true
@@ -41,6 +42,7 @@ const Card = styled.div(() => ({
 
 export const DesignTokenDocBlock = ({
   filterNames,
+  usageMap,
   categoryName,
   maxHeight = 600,
   showValueColumn = true,
@@ -64,6 +66,7 @@ export const DesignTokenDocBlock = ({
   return (
     <DesignTokenDocBlockView
       filterNames={filterNames}
+      usageMap={usageMap}
       categories={tab.categories}
       viewType={viewType}
       maxHeight={maxHeight}
@@ -93,6 +96,7 @@ function DesignTokenDocBlockView({
   pageSize,
   presenters,
   filterNames,
+  usageMap,
   theme,
 }: DesignTokenDocBlockViewProps) {
   const { searchText, setSearchText, categories } = useTokenSearch(
@@ -119,6 +123,7 @@ function DesignTokenDocBlockView({
             showValueColumn={showValueColumn}
             presenters={presenters}
             filterNames={filterNames}
+            usageMap={usageMap}
             theme={theme}
           />
         </Card>
@@ -126,6 +131,7 @@ function DesignTokenDocBlockView({
       {viewType === "card" && (
         <TokenCards
           filterNames={filterNames}
+          usageMap={usageMap}
           categories={categories}
           padded={false}
           readonly

--- a/addon/src/components/Popup.tsx
+++ b/addon/src/components/Popup.tsx
@@ -1,0 +1,63 @@
+import { styled, keyframes } from "storybook/theming";
+import { transparentize } from "polished";
+
+const fadeIn = keyframes({
+  from: {
+    opacity: 0,
+    transform: "translateY(5px)",
+  },
+  to: {
+    opacity: 1,
+    transform: "translateY(0)",
+  },
+});
+
+export const Popup = styled.div(({ theme }) => ({
+  position: "absolute",
+  background: theme.background.content,
+  border: `1px solid ${theme.color.border}`,
+  borderRadius: theme.borderRadius,
+  padding: "12px 15px",
+  boxShadow: `0 4px 12px ${transparentize(0.85, theme.color.darker)}`,
+  color: theme.color.defaultText,
+  fontFamily: theme.typography.fonts.base,
+  fontSize: theme.typography.size.s2,
+  minWidth: 150,
+  maxWidth: 300,
+  zIndex: 1000,
+  animation: `${fadeIn} 0.2s ease-out`,
+
+  "& > div:first-child": {
+    fontWeight: theme.typography.weight.bold,
+    marginBottom: 8,
+    color: theme.color.darkest,
+  },
+
+  "& > ul": {
+    margin: 0,
+    padding: 0,
+    listStyle: "none",
+    maxHeight: 200,
+    overflowY: "auto",
+
+    "& > li": {
+      padding: "4px 8px",
+      borderRadius: theme.borderRadius / 2,
+      color: transparentize(0.1, theme.color.defaultText),
+      background: transparentize(0.95, theme.color.medium),
+      marginBottom: 4,
+      transition: "background 0.2s ease",
+      whiteSpace: "nowrap",
+      overflow: "hidden",
+      textOverflow: "ellipsis",
+
+      "&:hover": {
+        background: transparentize(0.85, theme.color.medium),
+      },
+
+      "&:last-child": {
+        marginBottom: 0,
+      },
+    },
+  },
+}));

--- a/addon/src/hooks/usePopup.ts
+++ b/addon/src/hooks/usePopup.ts
@@ -1,0 +1,82 @@
+import { useState, useRef, useLayoutEffect, useCallback } from "react";
+
+interface PopupState {
+  top: number;
+  left: number;
+  tokenName: string;
+}
+
+interface UsePopupProps<T> {
+  usageMap?: Record<string, string[]>;
+  getElementRef: (item: T) => HTMLElement | null;
+  getTokenName: (item: T) => string;
+}
+
+export function usePopup<T>({
+  usageMap,
+  getElementRef,
+  getTokenName,
+}: UsePopupProps<T>) {
+  const [popup, setPopup] = useState<PopupState | null>(null);
+  const timeoutRef = useRef<number | null>(null);
+  const popupRef = useRef<HTMLDivElement | null>(null);
+
+  const handleContextMenu = useCallback(
+    (event: React.MouseEvent, item: T) => {
+      const tokenName = getTokenName(item);
+      if (!usageMap) return;
+      event.preventDefault();
+
+      const element = getElementRef(item);
+      if (!element) return;
+
+      const rect = element.getBoundingClientRect();
+      const top = rect.bottom + window.scrollY + 5; // Position below the element
+      const left = rect.left + window.scrollX;
+
+      setPopup({ top, left, tokenName });
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    },
+    [usageMap, getElementRef, getTokenName]
+  );
+
+  const closePopup = useCallback(() => {
+    setPopup(null);
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+  }, []);
+
+  useLayoutEffect(() => {
+    const handleClick = (event: MouseEvent) => {
+      if (
+        popupRef.current &&
+        !popupRef.current.contains(event.target as Node)
+      ) {
+        closePopup();
+      }
+    };
+
+    const handleScroll = (event: Event) => {
+      if (!popup) return;
+
+      const target = event.target as Node;
+      if (popupRef.current && !popupRef.current.contains(target)) {
+        if (timeoutRef.current) clearTimeout(timeoutRef.current);
+        timeoutRef.current = window.setTimeout(closePopup, 2000);
+      }
+    };
+
+    document.addEventListener("click", handleClick);
+    document.addEventListener("scroll", handleScroll, true);
+    return () => {
+      document.removeEventListener("click", handleClick);
+      document.removeEventListener("scroll", handleScroll, true);
+    };
+  }, [popup, closePopup]);
+
+  return {
+    popup,
+    popupRef,
+    handleContextMenu,
+    closePopup,
+  };
+}

--- a/addon/src/stories/Introduction.mdx
+++ b/addon/src/stories/Introduction.mdx
@@ -31,3 +31,14 @@ Display design token documentation generated from your stylesheets and icon file
   categoryName="Colors"
   viewType="card"
 />
+
+## Token usage map
+
+<DesignTokenDocBlock
+  categoryName="Colors"
+  viewType="card"
+  usageMap={{
+    "--b100": ["Button", "CardHeader"],
+    "--b200": ["Modal"],
+  }}
+/>

--- a/addon/yarn.lock
+++ b/addon/yarn.lock
@@ -1421,6 +1421,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/react-dom@npm:^19.1.1":
+  version: 19.1.6
+  resolution: "@types/react-dom@npm:19.1.6"
+  peerDependencies:
+    "@types/react": ^19.0.0
+  checksum: 10c0/7ba74eee2919e3f225e898b65fdaa16e54952aaf9e3472a080ddc82ca54585e46e60b3c52018d21d4b7053f09d27b8293e9f468b85f9932ff452cd290cc131e8
+  languageName: node
+  linkType: hard
+
 "@types/react@npm:^19.1.6":
   version: 19.1.6
   resolution: "@types/react@npm:19.1.6"
@@ -4887,6 +4896,7 @@ __metadata:
     "@types/node": "npm:^20.19.0"
     "@types/prettier": "npm:^2.7.2"
     "@types/react": "npm:^19.1.6"
+    "@types/react-dom": "npm:^19.1.1"
     "@uidotdev/usehooks": "npm:^2.4.1"
     "@vitejs/plugin-react": "npm:^4.5.1"
     glob: "npm:^9.3.0"


### PR DESCRIPTION
Hey folks, I’m adding a new feature to the library that our team needed. We had a use case where our designers wanted to know where our Figma tokens are used (i.e., in which components).

To support this, we’ve added a prebuild step before running Storybook (specifically, an NX script that traverses our library and detects Figma token usage in components).

The implementation is straightforward: it uses an object map where Figma tokens are the keys, and the values are arrays of component names (see example image).

By providing the optional usageMap, users can preview token usage by right-clicking on a table row—a modal will pop up displaying the relevant information.

I’ve also added a fallback: if a usageMap is provided but some tokens aren’t used in any components, we display a message indicating the token is either global or unused.

Please shout if any changes are needed or feel free to edit directly. I’ve also fixed the DTS type generation.

<img width="1100" alt="Screenshot 2025-06-19 at 11 08 42" src="https://github.com/user-attachments/assets/3ef1c4de-9dec-4f43-b3c8-125cba0bf34e" />
<img width="431" alt="Screenshot 2025-06-19 at 11 08 12" src="https://github.com/user-attachments/assets/3bb57986-dcea-43f0-b821-33983ae5f9e9" />
<img width="621" alt="Screenshot 2025-06-19 at 11 12 05" src="https://github.com/user-attachments/assets/868079d9-ebc3-4861-8388-8a16d48d0141" />
